### PR TITLE
Patch v2.2.1

### DIFF
--- a/.github/workflows/publish-dashboards.yml
+++ b/.github/workflows/publish-dashboards.yml
@@ -1,4 +1,4 @@
-name: Publish Dashboards
+name: 📊 Publish Dashboards
 
 on:
   push:

--- a/grafana/clipify-vm01-overview-v2.json
+++ b/grafana/clipify-vm01-overview-v2.json
@@ -41,7 +41,7 @@
 										"group": "influxdb",
 										"kind": "DataQuery",
 										"spec": {
-											"query": "from(bucket: \"clipify_monitor\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"clipify_vm01\")\n  |> filter(fn: (r) => r[\"_field\"] == \"db_latencyMs\")\n  |> keep(columns: [\"_time\", \"_value\", \"_field\"])\n  |> group(columns: [\"_field\"])\n  |> last()"
+											"query": "from(bucket: \"clipify_monitor\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"clipify_vm01\")\n  |> filter(fn: (r) => r[\"_field\"] == \"db_pingMs\")\n  |> keep(columns: [\"_time\", \"_value\", \"_field\"])\n  |> group(columns: [\"_field\"])\n  |> last()"
 										},
 										"version": "v0"
 									},
@@ -53,10 +53,10 @@
 						"transformations": []
 					}
 				},
-				"description": "Latest database latency for clipify_vm01.",
+				"description": "Latest database ping for clipify_vm01.",
 				"id": 3,
 				"links": [],
-				"title": "DB Latency",
+				"title": "DB Ping",
 				"vizConfig": {
 					"group": "stat",
 					"kind": "VizConfig",
@@ -76,15 +76,15 @@
 										},
 										{
 											"color": "yellow",
-											"value": 180
+											"value": 25
 										},
 										{
 											"color": "orange",
-											"value": 250
+											"value": 50
 										},
 										{
 											"color": "red",
-											"value": 400
+											"value": 100
 										}
 									]
 								},
@@ -94,12 +94,12 @@
 								{
 									"matcher": {
 										"id": "byName",
-										"options": "db_latencyMs"
+										"options": "db_pingMs"
 									},
 									"properties": [
 										{
 											"id": "displayName",
-											"value": "DB Latency"
+											"value": "DB Ping"
 										}
 									]
 								}
@@ -819,7 +819,7 @@
 										"group": "influxdb",
 										"kind": "DataQuery",
 										"spec": {
-											"query": "from(bucket: \"clipify_monitor\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"clipify_vm01\")\n  |> filter(fn: (r) =>\n      r[\"_field\"] == \"db_latencyMs\"\n    )\n  |> keep(columns: [\"_time\", \"_value\", \"_field\"])\n  |> group(columns: [\"_field\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
+											"query": "from(bucket: \"clipify_monitor\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"clipify_vm01\")\n  |> filter(fn: (r) =>\n      r[\"_field\"] == \"db_pingMs\" or\n      r[\"_field\"] == \"db_healthAggregationMs\"\n    )\n  |> keep(columns: [\"_time\", \"_value\", \"_field\"])\n  |> group(columns: [\"_field\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)"
 										},
 										"version": "v0"
 									},
@@ -831,10 +831,10 @@
 						"transformations": []
 					}
 				},
-				"description": "Trend of database latency.",
+				"description": "Trend of database ping and full health aggregation duration.",
 				"id": 13,
 				"links": [],
-				"title": "DB Latency Over Time",
+				"title": "Health Timing Over Time",
 				"vizConfig": {
 					"group": "timeseries",
 					"kind": "VizConfig",
@@ -906,12 +906,72 @@
 								{
 									"matcher": {
 										"id": "byName",
-										"options": "db_latencyMs"
+										"options": "db_pingMs"
 									},
 									"properties": [
 										{
 											"id": "displayName",
-											"value": "DB Latency"
+											"value": "DB Ping"
+										},
+										{
+											"id": "thresholds",
+											"value": {
+												"mode": "absolute",
+												"steps": [
+													{
+														"color": "green",
+														"value": 0
+													},
+													{
+														"color": "#EAB839",
+														"value": 25
+													},
+													{
+														"color": "orange",
+														"value": 50
+													},
+													{
+														"color": "red",
+														"value": 100
+													}
+												]
+											}
+										}
+									]
+								},
+								{
+									"matcher": {
+										"id": "byName",
+										"options": "db_healthAggregationMs"
+									},
+									"properties": [
+										{
+											"id": "displayName",
+											"value": "Health Aggregation"
+										},
+										{
+											"id": "thresholds",
+											"value": {
+												"mode": "absolute",
+												"steps": [
+													{
+														"color": "green",
+														"value": 0
+													},
+													{
+														"color": "#EAB839",
+														"value": 180
+													},
+													{
+														"color": "orange",
+														"value": 250
+													},
+													{
+														"color": "red",
+														"value": 400
+													}
+												]
+											}
 										}
 									]
 								}

--- a/src/app/actions/database.ts
+++ b/src/app/actions/database.ts
@@ -6,7 +6,7 @@ import { AuthenticatedUser, Overlay, Playlist, TwitchUserResponse, TwitchTokenAp
 import { getUserDetails, getUsersDetailsBulk, refreshAccessTokenWithContext, subscribeToReward, syncOwnerClipCache } from "@actions/twitch";
 import { syncProductUpdatesContact, getProductUpdatesSubscriptionStatus } from "@actions/newsletter";
 import { isTitleBlocked } from "@/app/utils/regexFilter";
-import { eq, inArray, and, or, isNull, lt, gt, sql, desc, max } from "drizzle-orm";
+import { eq, inArray, and, or, isNull, lt, gt, sql, desc, max, asc } from "drizzle-orm";
 import { validateAuth, validateAdminAuth } from "@actions/auth";
 import { encryptToken, decryptToken } from "@lib/tokenCrypto";
 import { getFeatureAccess } from "@lib/featureAccess";
@@ -1879,7 +1879,7 @@ export async function getClipQueue(overlayId: string, secret?: string) {
 
 export async function getFirstFromClipQueueByOverlayId(overlayId: string) {
 	try {
-		const result = await db.select().from(queueTable).where(eq(queueTable.overlayId, overlayId)).limit(1).execute();
+		const result = await db.select().from(queueTable).where(eq(queueTable.overlayId, overlayId)).orderBy(asc(queueTable.queuedAt)).limit(1).execute();
 
 		return result[0] || null;
 	} catch (error) {
@@ -1990,7 +1990,7 @@ export async function getModQueue(broadcasterId: string) {
 
 export async function getFirstFromModQueueByBroadcasterId(broadcasterId: string) {
 	try {
-		const result = await db.select().from(modQueueTable).where(eq(modQueueTable.broadcasterId, broadcasterId)).limit(1).execute();
+		const result = await db.select().from(modQueueTable).where(eq(modQueueTable.broadcasterId, broadcasterId)).orderBy(asc(modQueueTable.queuedAt)).limit(1).execute();
 		/* istanbul ignore next: fallback value */
 		return result[0] || null;
 	} catch (error) {

--- a/src/app/actions/database.ts
+++ b/src/app/actions/database.ts
@@ -2,8 +2,26 @@
 
 import { tokenTable, usersTable, overlaysTable, playlistsTable, playlistClipsTable, queueTable, settingsTable, modQueueTable, editorsTable, twitchCacheTable } from "@/db/schema";
 import { db, QueryClient } from "@/db/client";
-import { AuthenticatedUser, Overlay, Playlist, TwitchUserResponse, TwitchTokenApiResponse, UserToken, Plan, Role, UserSettings, TwitchCacheType, StatusOptions, OverlayType, PlaybackMode, MaxDurationMode, TwitchClip } from "@types";
-import { getUserDetails, getUsersDetailsBulk, refreshAccessTokenWithContext, subscribeToReward, syncOwnerClipCache } from "@actions/twitch";
+import {
+	AuthenticatedUser,
+	ClipQueueItem,
+	ModQueueItem,
+	Overlay,
+	Playlist,
+	TwitchUserResponse,
+	TwitchTokenApiResponse,
+	UserToken,
+	Plan,
+	Role,
+	UserSettings,
+	TwitchCacheType,
+	StatusOptions,
+	OverlayType,
+	PlaybackMode,
+	MaxDurationMode,
+	TwitchClip,
+} from "@types";
+import { getTwitchClipLookup, getUserDetails, getUsersDetailsBulk, refreshAccessTokenWithContext, subscribeToReward, syncOwnerClipCache } from "@actions/twitch";
 import { syncProductUpdatesContact, getProductUpdatesSubscriptionStatus } from "@actions/newsletter";
 import { isTitleBlocked } from "@/app/utils/regexFilter";
 import { eq, inArray, and, or, isNull, lt, gt, sql, desc, max, asc } from "drizzle-orm";
@@ -1879,7 +1897,7 @@ export async function getClipQueue(overlayId: string, secret?: string) {
 
 export async function getFirstFromClipQueueByOverlayId(overlayId: string) {
 	try {
-		const result = await db.select().from(queueTable).where(eq(queueTable.overlayId, overlayId)).orderBy(asc(queueTable.queuedAt)).limit(1).execute();
+		const result = await db.select().from(queueTable).where(eq(queueTable.overlayId, overlayId)).orderBy(asc(queueTable.queuedAt), asc(queueTable.id)).limit(1).execute();
 
 		return result[0] || null;
 	} catch (error) {
@@ -1990,12 +2008,52 @@ export async function getModQueue(broadcasterId: string) {
 
 export async function getFirstFromModQueueByBroadcasterId(broadcasterId: string) {
 	try {
-		const result = await db.select().from(modQueueTable).where(eq(modQueueTable.broadcasterId, broadcasterId)).orderBy(asc(modQueueTable.queuedAt)).limit(1).execute();
+		const result = await db.select().from(modQueueTable).where(eq(modQueueTable.broadcasterId, broadcasterId)).orderBy(asc(modQueueTable.queuedAt), asc(modQueueTable.id)).limit(1).execute();
 		/* istanbul ignore next: fallback value */
 		return result[0] || null;
 	} catch (error) {
 		console.error("Error fetching first clip from mod queue:", error);
 		throw new Error("Failed to fetch first clip from mod queue");
+	}
+}
+
+export async function getFirstValidQueuedClip(
+	overlayId: string,
+	secret?: string,
+): Promise<{ clip: TwitchClip; queueItem: ModQueueItem | ClipQueueItem } | null> {
+	try {
+		const overlay = await requireOverlaySecretAccess(overlayId, secret);
+		if (!overlay) return null;
+
+		while (true) {
+			const modClip = await getFirstFromModQueueByBroadcasterId(overlay.ownerId);
+			if (modClip) {
+				const clipLookup = await getTwitchClipLookup(modClip.clipId, overlay.ownerId);
+				if (clipLookup.clip) return { clip: clipLookup.clip, queueItem: modClip };
+				if (clipLookup.status !== "not_found") return null;
+
+				await db
+					.delete(modQueueTable)
+					.where(and(eq(modQueueTable.id, modClip.id), eq(modQueueTable.broadcasterId, overlay.ownerId)))
+					.execute();
+				continue;
+			}
+
+			const queuedClip = await getFirstFromClipQueueByOverlayId(overlayId);
+			if (!queuedClip) return null;
+
+			const clipLookup = await getTwitchClipLookup(queuedClip.clipId, overlay.ownerId);
+			if (clipLookup.clip) return { clip: clipLookup.clip, queueItem: queuedClip };
+			if (clipLookup.status !== "not_found") return null;
+
+			await db
+				.delete(queueTable)
+				.where(and(eq(queueTable.id, queuedClip.id), eq(queueTable.overlayId, overlayId)))
+				.execute();
+		}
+	} catch (error) {
+		console.error("Error fetching first valid queued clip:", error);
+		throw new Error("Failed to fetch first valid queued clip");
 	}
 }
 

--- a/src/app/actions/twitch.ts
+++ b/src/app/actions/twitch.ts
@@ -732,12 +732,20 @@ export async function verifyToken(user: AuthenticatedUser) {
 }
 
 export async function getTwitchClip(clipId: string, creatorId: string): Promise<null | TwitchClip> {
+	const result = await getTwitchClipLookup(clipId, creatorId);
+	return result.clip;
+}
+
+export async function getTwitchClipLookup(
+	clipId: string,
+	creatorId: string,
+): Promise<{ clip: TwitchClip | null; status: "ok" | "not_found" | "transient_error" }> {
 	const url = "https://api.twitch.tv/helix/clips";
 	const token = await getAccessTokenServer(creatorId);
 
 	if (!token) {
 		console.error("No access token found for creatorId:", creatorId);
-		return null;
+		return { clip: null, status: "transient_error" };
 	}
 
 	try {
@@ -753,12 +761,12 @@ export async function getTwitchClip(clipId: string, creatorId: string): Promise<
 		const clip = response.data.data[0];
 		if (!clip) {
 			console.error("Clip not found for ID:", clipId);
-			return null;
+			return { clip: null, status: "not_found" };
 		}
-		return clip;
+		return { clip, status: "ok" };
 	} catch (error) {
 		logTwitchError("Error fetching Twitch clip", error);
-		return null;
+		return { clip: null, status: "transient_error" };
 	}
 }
 

--- a/src/app/components/overlayPlayer.tsx
+++ b/src/app/components/overlayPlayer.tsx
@@ -2,12 +2,12 @@
 
 import { type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type RefObject, type SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ClipQueueItem, ModQueueItem, Overlay, PlaybackMode, TwitchClip, TwitchClipGqlData, TwitchClipGqlResponse, TwitchClipVideoQuality, VideoClip } from "@types";
-import { getAvatar, getDemoClip, getGameDetails, getTwitchClip, getTwitchClipBatch, resolvePlayableClip, subscribeToChat } from "@actions/twitch";
+import { getAvatar, getDemoClip, getGameDetails, getTwitchClipBatch, resolvePlayableClip, subscribeToChat } from "@actions/twitch";
 import PlayerOverlay from "@components/playerOverlay";
 import { Avatar, Button, Link } from "@heroui/react";
 import { motion, AnimatePresence } from "framer-motion";
 import axios from "axios";
-import { getFirstFromClipQueue, getFirstFromModQueue, removeFromClipQueue, removeFromModQueue } from "@actions/database";
+import { getFirstValidQueuedClip, removeFromClipQueue, removeFromModQueue } from "@actions/database";
 import Logo from "@components/logo";
 import { IconAlertTriangle, IconPlayerPauseFilled, IconPlayerPlayFilled, IconVolume, IconVolumeOff } from "@tabler/icons-react";
 import { clamp, getSlotOpacity, parseThemeFontSetting, sanitizeFontCssUrl, trimCache } from "./overlayPlayer.utils";
@@ -855,27 +855,6 @@ export default function OverlayPlayer({
 		return null;
 	}, []);
 
-	const getFirstQueClip = useCallback(async (): Promise<ModQueueItem | ClipQueueItem | null> => {
-		if (isEmbed || isDemoPlayer) return null;
-
-		const modClip = await getFirstFromModQueue(overlay.id, overlaySecret);
-		if (modClip) return modClip;
-
-		const queClip = await getFirstFromClipQueue(overlay.id, overlaySecret);
-		return queClip ?? null;
-	}, [isEmbed, isDemoPlayer, overlay.id, overlaySecret]);
-
-	const discardQueueItem = useCallback(
-		async (queueItem: ModQueueItem | ClipQueueItem | null | undefined) => {
-			if (!queueItem) return;
-			await Promise.allSettled([
-				removeFromModQueue(queueItem.id, overlay.id, overlaySecret),
-				removeFromClipQueue(queueItem.id, overlay.id, overlaySecret),
-			]);
-		},
-		[overlay.id, overlaySecret],
-	);
-
 	type ClipCandidate = { clip: TwitchClip; queueItem?: ModQueueItem | ClipQueueItem };
 
 	const getRandomClip = useCallback(async (): Promise<ClipCandidate | null> => {
@@ -884,12 +863,9 @@ export default function OverlayPlayer({
 			if (demoClip) return { clip: demoClip };
 		}
 
-		for (let attempt = 0; attempt < 25; attempt += 1) {
-			const queClip = await getFirstQueClip();
-			if (!queClip) break;
-			const clip = await getTwitchClip(queClip.clipId, overlay.ownerId);
-			if (clip != null) return { clip, queueItem: queClip };
-			await discardQueueItem(queClip);
+		if (!isEmbed && !isDemoPlayer) {
+			const queuedClip = await getFirstValidQueuedClip(overlay.id, overlaySecret);
+			if (queuedClip) return queuedClip;
 		}
 
 		let availableClips = clipPoolRef.current;
@@ -907,8 +883,12 @@ export default function OverlayPlayer({
 		if (candidates.length === 0) {
 			const refreshedClips = await refreshClipPool();
 			if (Array.isArray(refreshedClips) && refreshedClips.length > 0) {
-				availableClips = clipPoolRef.current.length > 0 ? clipPoolRef.current : refreshedClips;
+				availableClips = refreshedClips;
 				candidates = availableClips.filter((c) => !played.includes(c.id) && c.id !== currentId && c.id !== nextId);
+			} else if (Array.isArray(availableClips) && availableClips.length > 0) {
+				setPlayedClips([]);
+				playedClipsRef.current = [];
+				candidates = availableClips.filter((c) => c.id !== currentId && c.id !== nextId);
 			}
 		}
 
@@ -1010,7 +990,7 @@ export default function OverlayPlayer({
 			if (playable) return { clip: playable };
 		}
 		return null;
-	}, [discardQueueItem, getFirstQueClip, getFirstFromDemoQueue, isDemoPlayer, overlay.ownerId, playbackMode, refreshClipPool]);
+	}, [getFirstFromDemoQueue, isDemoPlayer, isEmbed, overlay.id, overlay.ownerId, overlaySecret, playbackMode, refreshClipPool]);
 
 	const consumeQueueItem = useCallback(
 		async (queueItem: ModQueueItem | ClipQueueItem | null | undefined) => {

--- a/src/app/components/overlayPlayer.tsx
+++ b/src/app/components/overlayPlayer.tsx
@@ -487,6 +487,13 @@ export default function OverlayPlayer({
 		playedClipsRef.current = playedClips;
 	}, [playedClips]);
 
+	const markClipAsPlayed = useCallback((clipId: string | null | undefined) => {
+		if (!clipId) return;
+		if (playedClipsRef.current.includes(clipId)) return;
+		playedClipsRef.current = [...playedClipsRef.current, clipId];
+		setPlayedClips(playedClipsRef.current);
+	}, []);
+
 	const nextClipRef = useRef<VideoClip | null>(null);
 	const nextQueueItemRef = useRef<ModQueueItem | ClipQueueItem | null>(null);
 	useEffect(() => {
@@ -858,6 +865,17 @@ export default function OverlayPlayer({
 		return queClip ?? null;
 	}, [isEmbed, isDemoPlayer, overlay.id, overlaySecret]);
 
+	const discardQueueItem = useCallback(
+		async (queueItem: ModQueueItem | ClipQueueItem | null | undefined) => {
+			if (!queueItem) return;
+			await Promise.allSettled([
+				removeFromModQueue(queueItem.id, overlay.id, overlaySecret),
+				removeFromClipQueue(queueItem.id, overlay.id, overlaySecret),
+			]);
+		},
+		[overlay.id, overlaySecret],
+	);
+
 	type ClipCandidate = { clip: TwitchClip; queueItem?: ModQueueItem | ClipQueueItem };
 
 	const getRandomClip = useCallback(async (): Promise<ClipCandidate | null> => {
@@ -866,10 +884,12 @@ export default function OverlayPlayer({
 			if (demoClip) return { clip: demoClip };
 		}
 
-		const queClip = await getFirstQueClip();
-		if (queClip) {
+		for (let attempt = 0; attempt < 25; attempt += 1) {
+			const queClip = await getFirstQueClip();
+			if (!queClip) break;
 			const clip = await getTwitchClip(queClip.clipId, overlay.ownerId);
 			if (clip != null) return { clip, queueItem: queClip };
+			await discardQueueItem(queClip);
 		}
 
 		let availableClips = clipPoolRef.current;
@@ -883,6 +903,14 @@ export default function OverlayPlayer({
 		const currentId = clipRef.current?.id;
 
 		let candidates = availableClips.filter((c) => !played.includes(c.id) && c.id !== currentId && c.id !== nextId);
+
+		if (candidates.length === 0) {
+			const refreshedClips = await refreshClipPool();
+			if (Array.isArray(refreshedClips) && refreshedClips.length > 0) {
+				availableClips = clipPoolRef.current.length > 0 ? clipPoolRef.current : refreshedClips;
+				candidates = availableClips.filter((c) => !played.includes(c.id) && c.id !== currentId && c.id !== nextId);
+			}
+		}
 
 		if (candidates.length === 0) {
 			setPlayedClips([]);
@@ -982,7 +1010,7 @@ export default function OverlayPlayer({
 			if (playable) return { clip: playable };
 		}
 		return null;
-	}, [getFirstQueClip, getFirstFromDemoQueue, isDemoPlayer, overlay.ownerId, playbackMode, refreshClipPool]);
+	}, [discardQueueItem, getFirstQueClip, getFirstFromDemoQueue, isDemoPlayer, overlay.ownerId, playbackMode, refreshClipPool]);
 
 	const consumeQueueItem = useCallback(
 		async (queueItem: ModQueueItem | ClipQueueItem | null | undefined) => {
@@ -1055,6 +1083,7 @@ export default function OverlayPlayer({
 
 			const prefetched = nextClipRef.current;
 			if (prefetched) {
+				markClipAsPlayed(clipRef.current?.id);
 				nextClipRef.current = null;
 				setNextClip(null);
 				await consumeQueueItem(nextQueueItemRef.current);
@@ -1075,6 +1104,7 @@ export default function OverlayPlayer({
 			if (myReqId !== requestIdRef.current) return;
 
 			if (built) {
+				markClipAsPlayed(clipRef.current?.id);
 				await consumeQueueItem(candidate.queueItem);
 				activateClipImmediately(built);
 			}
@@ -1085,7 +1115,7 @@ export default function OverlayPlayer({
 				advanceClip().catch((error) => console.error("Error advancing clip after pending skip:", error));
 			}
 		}
-	}, [activateClipImmediately, buildVideoClipFast, consumeQueueItem, getRandomClip]);
+	}, [activateClipImmediately, buildVideoClipFast, consumeQueueItem, getRandomClip, markClipAsPlayed]);
 
 	const resetPrefetch = useCallback(() => {
 		prefetchAbortRef.current?.abort();
@@ -1707,10 +1737,9 @@ export default function OverlayPlayer({
 					},
 				});
 			}
-			playedClipsRef.current = [...playedClipsRef.current, clipRef.current.id];
-			setPlayedClips(playedClipsRef.current);
+			markClipAsPlayed(clipRef.current.id);
 		}
-	}, [activeSlot, isCrossfading, isDemoPlayer, overlay.id, overlaySecret, playbackMode, plausible]);
+	}, [activeSlot, isCrossfading, isDemoPlayer, markClipAsPlayed, overlay.id, overlaySecret, playbackMode, plausible]);
 
 	const handleTimeUpdate = useCallback(
 		(slot: "a" | "b", video: HTMLVideoElement | null) => {
@@ -1854,8 +1883,7 @@ export default function OverlayPlayer({
 			if (isCrossfading) return;
 			if (holdLastFrameRef.current) return;
 			setShowOverlay(false);
-			if (clipA) playedClipsRef.current = [...playedClipsRef.current, clipA.id];
-			setPlayedClips(playedClipsRef.current);
+			markClipAsPlayed(clipA?.id);
 			advanceClip();
 		};
 
@@ -1865,8 +1893,7 @@ export default function OverlayPlayer({
 			if (isCrossfading) return;
 			if (holdLastFrameRef.current) return;
 			setShowOverlay(false);
-			if (clipB) playedClipsRef.current = [...playedClipsRef.current, clipB.id];
-			setPlayedClips(playedClipsRef.current);
+			markClipAsPlayed(clipB?.id);
 			advanceClip();
 		};
 

--- a/test/app/actions/database.coverage.test.ts
+++ b/test/app/actions/database.coverage.test.ts
@@ -98,9 +98,9 @@ jest.mock("@/db/schema", () => ({
 	overlaysTable: { id: "overlays.id", ownerId: "overlays.owner_id", secret: "overlays.secret", status: "overlays.status", updatedAt: "overlays.updated_at" },
 	playlistsTable: { id: "playlists.id", ownerId: "playlists.owner_id", createdAt: "playlists.created_at" },
 	playlistClipsTable: { playlistId: "playlist_clips.playlist_id", clipId: "playlist_clips.clip_id", position: "playlist_clips.position" },
-	queueTable: { id: "queue.id", overlayId: "queue.overlay_id" },
+	queueTable: { id: "queue.id", overlayId: "queue.overlay_id", queuedAt: "queue.queued_at" },
 	settingsTable: { id: "settings.id" },
-	modQueueTable: { id: "mod_queue.id", broadcasterId: "mod_queue.broadcaster_id" },
+	modQueueTable: { id: "mod_queue.id", broadcasterId: "mod_queue.broadcaster_id", queuedAt: "mod_queue.queued_at" },
 	tokenTable: { id: "token.id" },
 	editorsTable: { id: "editors.id", editorId: "editors.editor_id", userId: "editors.user_id" },
 	twitchCacheTable: { type: "twitch_cache.type", key: "twitch_cache.key", value: "twitch_cache.value", expiresAt: "twitch_cache.expires_at", fetchedAt: "twitch_cache.fetched_at" },
@@ -122,6 +122,7 @@ jest.mock("drizzle-orm", () => ({
 		},
 	),
 	desc: jest.fn(() => "desc"),
+	asc: jest.fn(() => "asc"),
 	max: jest.fn(() => "max"),
 }));
 

--- a/test/app/actions/database.coverage.test.ts
+++ b/test/app/actions/database.coverage.test.ts
@@ -134,6 +134,7 @@ jest.mock("@actions/auth", () => ({
 }));
 
 const twitch = {
+	getTwitchClipLookup: jest.fn(),
 	getUserDetails: jest.fn(),
 	getUsersDetailsBulk: jest.fn(),
 	refreshAccessTokenWithContext: jest.fn(),
@@ -188,6 +189,7 @@ describe("database.ts coverage tests", () => {
 		dbUpdate.mockImplementation(() => makeUpdateChain());
 		dbDelete.mockImplementation(() => makeDeleteChain());
 		validateAuth.mockResolvedValue({ id: "user-1", email: "e", username: "u" });
+		twitch.getTwitchClipLookup.mockReset();
 		twitch.getUserDetails.mockReset();
 		twitch.getUsersDetailsBulk.mockReset();
 	});

--- a/test/app/actions/database.queues.test.ts
+++ b/test/app/actions/database.queues.test.ts
@@ -13,11 +13,13 @@ const queueTable = {
 	id: "queue.id",
 	overlayId: "queue.overlay_id",
 	clipId: "queue.clip_id",
+	queuedAt: "queue.queued_at",
 };
 const modQueueTable = {
 	id: "mod_queue.id",
 	broadcasterId: "mod_queue.broadcaster_id",
 	clipId: "mod_queue.clip_id",
+	queuedAt: "mod_queue.queued_at",
 };
 const overlaysTable = {
     id: "overlays.id",
@@ -37,6 +39,7 @@ function makeSelectChain() {
 	const chain: Record<string, unknown> = {};
 	chain.from = () => chain;
 	chain.where = () => chain;
+	chain.orderBy = () => chain;
 	chain.limit = () => chain;
 	chain.execute = async () => (selectQueue.length > 0 ? selectQueue.shift() : []);
 	return chain;
@@ -98,6 +101,7 @@ jest.mock("drizzle-orm", () => ({
 		raw: jest.fn((value: unknown) => String(value)),
 	}),
 	desc: jest.fn(() => "desc"),
+	asc: jest.fn(() => "asc"),
 	max: jest.fn(() => "max"),
 }));
 

--- a/test/app/actions/database.queues.test.ts
+++ b/test/app/actions/database.queues.test.ts
@@ -112,6 +112,11 @@ jest.mock("@actions/auth", () => ({
 	validateAdminAuth,
 }));
 
+const twitch = {
+	getTwitchClipLookup: jest.fn(),
+};
+jest.mock("@actions/twitch", () => twitch);
+
 async function loadDatabaseActions() {
 	jest.resetModules();
 	return import("@/app/actions/database");
@@ -126,6 +131,7 @@ describe("actions/database queue logic", () => {
 		dbSelect.mockImplementation(() => makeSelectChain());
 		dbInsert.mockImplementation((table: unknown) => makeInsertChain(table));
 		dbDelete.mockImplementation((table: unknown) => makeDeleteChain(table));
+		twitch.getTwitchClipLookup.mockResolvedValue({ clip: null, status: "transient_error" });
 	});
 
 	it("adds to clip queue", async () => {
@@ -269,6 +275,37 @@ describe("actions/database queue logic", () => {
         await clearModQueue("overlay-1", "wrong-secret");
         expect(deleteCalls.some(call => call.table === modQueueTable)).toBe(false);
     });
+
+	it("keeps a queued mod clip when the Twitch lookup fails transiently", async () => {
+		const { getFirstValidQueuedClip } = await loadDatabaseActions();
+		queueSelectResult([{ id: "overlay-1", secret: "secret-1", ownerId: "owner-1" }]); // overlay select
+		queueSelectResult([{ disabled: false }]); // owner select
+		queueSelectResult([{ id: "mod-1", clipId: "clip-1" }]); // mod queue select
+		twitch.getTwitchClipLookup.mockResolvedValue({ clip: null, status: "transient_error" });
+
+		const result = await getFirstValidQueuedClip("overlay-1", "secret-1");
+		expect(result).toBeNull();
+		expect(deleteCalls.some((call) => call.table === modQueueTable || call.table === queueTable)).toBe(false);
+	});
+
+	it("drops a missing queued mod clip and continues to the next queued clip", async () => {
+		const { getFirstValidQueuedClip } = await loadDatabaseActions();
+		queueSelectResult([{ id: "overlay-1", secret: "secret-1", ownerId: "owner-1" }]); // overlay select
+		queueSelectResult([{ disabled: false }]); // owner select
+		queueSelectResult([{ id: "mod-missing", clipId: "missing-clip" }]); // first mod queue select
+		queueSelectResult([]); // second mod queue select
+		queueSelectResult([{ id: "queue-valid", clipId: "valid-clip" }]); // clip queue select
+		twitch.getTwitchClipLookup
+			.mockResolvedValueOnce({ clip: null, status: "not_found" })
+			.mockResolvedValueOnce({ clip: { id: "valid-clip" }, status: "ok" });
+
+		const result = await getFirstValidQueuedClip("overlay-1", "secret-1");
+		expect(result).toEqual({
+			clip: { id: "valid-clip" },
+			queueItem: { id: "queue-valid", clipId: "valid-clip" },
+		});
+		expect(deleteCalls.some((call) => call.table === modQueueTable)).toBe(true);
+	});
 
     describe("error cases", () => {
         it("handles error in addToClipQueue", async () => {

--- a/test/app/components/overlayPlayer.test.tsx
+++ b/test/app/components/overlayPlayer.test.tsx
@@ -6,13 +6,11 @@ import OverlayPlayer from "@/app/components/overlayPlayer";
 const getAvatar = jest.fn();
 const getDemoClip = jest.fn();
 const getGameDetails = jest.fn();
-const getTwitchClip = jest.fn();
 const getTwitchClipBatch = jest.fn();
 const resolvePlayableClip = jest.fn();
 const subscribeToChat = jest.fn();
 
-const getFirstFromClipQueue = jest.fn();
-const getFirstFromModQueue = jest.fn();
+const getFirstValidQueuedClip = jest.fn();
 const removeFromClipQueue = jest.fn();
 const removeFromModQueue = jest.fn();
 
@@ -20,15 +18,13 @@ jest.mock("@actions/twitch", () => ({
 	getAvatar: (...args: unknown[]) => getAvatar(...args),
 	getDemoClip: (...args: unknown[]) => getDemoClip(...args),
 	getGameDetails: (...args: unknown[]) => getGameDetails(...args),
-	getTwitchClip: (...args: unknown[]) => getTwitchClip(...args),
 	getTwitchClipBatch: (...args: unknown[]) => getTwitchClipBatch(...args),
 	resolvePlayableClip: (...args: unknown[]) => resolvePlayableClip(...args),
 	subscribeToChat: (...args: unknown[]) => subscribeToChat(...args),
 }));
 
 jest.mock("@actions/database", () => ({
-	getFirstFromClipQueue: (...args: unknown[]) => getFirstFromClipQueue(...args),
-	getFirstFromModQueue: (...args: unknown[]) => getFirstFromModQueue(...args),
+	getFirstValidQueuedClip: (...args: unknown[]) => getFirstValidQueuedClip(...args),
 	removeFromClipQueue: (...args: unknown[]) => removeFromClipQueue(...args),
 	removeFromModQueue: (...args: unknown[]) => removeFromModQueue(...args),
 }));
@@ -255,12 +251,10 @@ describe("components/overlayPlayer", () => {
 		getAvatar.mockResolvedValue("https://avatar.example/owner.png");
 		getGameDetails.mockResolvedValue({ id: "game-1", name: "Game", box_art_url: "", igdb_id: "" });
 		getDemoClip.mockResolvedValue(null);
-		getTwitchClip.mockResolvedValue(null);
 		getTwitchClipBatch.mockResolvedValue([]);
 		resolvePlayableClip.mockImplementation(async (_ownerId: string, clip: unknown) => clip);
 		subscribeToChat.mockResolvedValue(undefined);
-		getFirstFromModQueue.mockResolvedValue(null);
-		getFirstFromClipQueue.mockResolvedValue(null);
+		getFirstValidQueuedClip.mockResolvedValue(null);
 		removeFromModQueue.mockResolvedValue(undefined);
 		removeFromClipQueue.mockResolvedValue(undefined);
 		for (const element of Array.from(document.head.querySelectorAll("link[id^='overlay-font-']"))) {
@@ -274,14 +268,12 @@ describe("components/overlayPlayer", () => {
 
 	it("prefers mod queue clips over normal queue during clip selection", async () => {
 		const queuedClip = buildClip("mod-priority", { title: "mod-priority-clip" });
-		getFirstFromModQueue.mockResolvedValue({ id: "mod-q1", clipId: queuedClip.id });
-		getTwitchClip.mockResolvedValue(queuedClip);
+		getFirstValidQueuedClip.mockResolvedValue({ clip: queuedClip, queueItem: { id: "mod-q1", clipId: queuedClip.id } });
 
 		render(<OverlayPlayer overlay={buildOverlay()} />);
 
 		await screen.findByText("mod-priority-clip");
-		expect(getFirstFromModQueue).toHaveBeenCalledWith("overlay-1", undefined);
-		expect(getFirstFromClipQueue).not.toHaveBeenCalled();
+		expect(getFirstValidQueuedClip).toHaveBeenCalledWith("overlay-1", undefined);
 		expect(removeFromModQueue).toHaveBeenCalledWith("mod-q1", "overlay-1", undefined);
 		expect(removeFromClipQueue).toHaveBeenCalledWith("mod-q1", "overlay-1", undefined);
 	});
@@ -758,8 +750,7 @@ describe("components/overlayPlayer", () => {
 
 	it("keeps current clip when skip cannot fetch new clips and cache refresh fails", async () => {
 		const queueClip = buildClip("queue-only", { title: "queue-only-clip" });
-		getFirstFromModQueue.mockResolvedValueOnce({ id: "queued-1", clipId: queueClip.id });
-		getTwitchClip.mockResolvedValue(queueClip);
+		getFirstValidQueuedClip.mockResolvedValueOnce({ clip: queueClip, queueItem: { id: "queued-1", clipId: queueClip.id } });
 		getTwitchClipBatch.mockRejectedValue(new Error("cache unavailable"));
 		const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
 
@@ -787,13 +778,12 @@ describe("components/overlayPlayer", () => {
 
 		const ws = MockWebSocket.instances[0];
 		await sendSocketPayload(ws, { type: "command", data: { name: "skip", data: "" } });
-		await waitFor(() => {
-			const laterFetchExcludesSkippedClip = getTwitchClipBatch.mock.calls.some((call) => {
-				const excludeIds = call[3];
-				return Array.isArray(excludeIds) && excludeIds.includes("skip-repeat-a");
-			});
-			expect(laterFetchExcludesSkippedClip).toBe(true);
-		});
+		await screen.findByText("skip-repeat-b");
+		expect(screen.queryByText("skip-repeat-a")).not.toBeInTheDocument();
+
+		await sendSocketPayload(ws, { type: "command", data: { name: "skip", data: "" } });
+		await screen.findByText("skip-repeat-c");
+		expect(screen.queryByText("skip-repeat-a")).not.toBeInTheDocument();
 	});
 
 	it("crossfades to prefetched clip when incoming slot is ready near clip end", async () => {
@@ -1080,25 +1070,24 @@ describe("components/overlayPlayer", () => {
 	it("queues a pending skip while advance is locked and drains it in finally", async () => {
 		const startClip = buildClip("queue-start", { title: "queue-start-clip", view_count: 999 });
 		const skipFirst = buildClip("skip-first", { title: "skip-first-clip", view_count: 300 });
-		let modQueueCall = 0;
+		let queueCall = 0;
 		let releaseSkipLock: (() => void) | null = null;
 
-		getFirstFromModQueue.mockImplementation(async () => {
-			modQueueCall += 1;
-			if (modQueueCall === 1) return { id: "mod-start", clipId: startClip.id };
-			if (modQueueCall === 2) return null;
-			if (modQueueCall === 3) {
+		getFirstValidQueuedClip.mockImplementation(async () => {
+			queueCall += 1;
+			if (queueCall === 1) return { clip: startClip, queueItem: { id: "mod-start", clipId: startClip.id } };
+			if (queueCall === 2) return null;
+			if (queueCall === 3) {
 				await new Promise<void>((resolve) => {
 					releaseSkipLock = resolve;
 				});
 				return null;
 			}
-			if (modQueueCall === 4) {
+			if (queueCall === 4) {
 				throw new Error("recursive-advance-failed");
 			}
 			return null;
 		});
-		getTwitchClip.mockResolvedValue(startClip);
 		getTwitchClipBatch.mockResolvedValueOnce([]).mockResolvedValueOnce([skipFirst]);
 		const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
 
@@ -1133,15 +1122,10 @@ describe("components/overlayPlayer", () => {
 		const firstClip = buildClip("prefetch-catch-a", { title: "prefetch-catch-a", view_count: 900 });
 		const secondClip = buildClip("prefetch-catch-b", { title: "prefetch-catch-b", view_count: 700 });
 		let queueCall = 0;
-		getFirstFromModQueue.mockImplementation(async () => {
+		getFirstValidQueuedClip.mockImplementation(async () => {
 			queueCall += 1;
-			if (queueCall === 1) return { id: "prefetch-q-1", clipId: firstClip.id };
-			if (queueCall === 2) return { id: "prefetch-q-2", clipId: secondClip.id };
-			return null;
-		});
-		getTwitchClip.mockImplementation(async (clipId: string) => {
-			if (clipId === firstClip.id) return firstClip;
-			if (clipId === secondClip.id) return secondClip;
+			if (queueCall === 1) return { clip: firstClip, queueItem: { id: "prefetch-q-1", clipId: firstClip.id } };
+			if (queueCall === 2) return { clip: secondClip, queueItem: { id: "prefetch-q-2", clipId: secondClip.id } };
 			return null;
 		});
 		getTwitchClipBatch.mockResolvedValue([]);
@@ -1168,15 +1152,10 @@ describe("components/overlayPlayer", () => {
 		const startClip = buildClip("queue-catch-start", { title: "queue-catch-start", view_count: 900 });
 		const skipClip = buildClip("queue-catch-next", { title: "queue-catch-next", view_count: 700 });
 		let queueCall = 0;
-		getFirstFromModQueue.mockImplementation(async () => {
+		getFirstValidQueuedClip.mockImplementation(async () => {
 			queueCall += 1;
-			if (queueCall === 1) return { id: "queue-catch-start-item", clipId: startClip.id };
-			if (queueCall === 3) return { id: "queue-catch-next-item", clipId: skipClip.id };
-			return null;
-		});
-		getTwitchClip.mockImplementation(async (clipId: string) => {
-			if (clipId === startClip.id) return startClip;
-			if (clipId === skipClip.id) return skipClip;
+			if (queueCall === 1) return { clip: startClip, queueItem: { id: "queue-catch-start-item", clipId: startClip.id } };
+			if (queueCall === 3) return { clip: skipClip, queueItem: { id: "queue-catch-next-item", clipId: skipClip.id } };
 			return null;
 		});
 		getTwitchClipBatch.mockResolvedValue([]);
@@ -1200,25 +1179,15 @@ describe("components/overlayPlayer", () => {
 
 	it("drops an invalid queue-head clip and continues to the next queued clip", async () => {
 		const validClip = buildClip("queue-valid-next", { title: "queue-valid-next", view_count: 700 });
-		let queueCall = 0;
-		getFirstFromModQueue.mockImplementation(async () => {
-			queueCall += 1;
-			if (queueCall === 1) return { id: "queue-invalid-item", clipId: "queue-invalid-clip" };
-			if (queueCall === 2) return { id: "queue-valid-item", clipId: validClip.id };
-			return null;
-		});
-		getTwitchClip.mockImplementation(async (clipId: string) => {
-			if (clipId === validClip.id) return validClip;
-			return null;
-		});
+		getFirstValidQueuedClip.mockResolvedValue({ clip: validClip, queueItem: { id: "queue-valid-item", clipId: validClip.id } });
 		getTwitchClipBatch.mockResolvedValue([]);
 
 		render(<OverlayPlayer overlay={buildOverlay({ playbackMode: "top" })} />);
 		await screen.findByText("queue-valid-next");
 
 		await waitFor(() => {
-			expect(removeFromModQueue).toHaveBeenCalledWith("queue-invalid-item", "overlay-1", undefined);
-			expect(removeFromClipQueue).toHaveBeenCalledWith("queue-invalid-item", "overlay-1", undefined);
+			expect(removeFromModQueue).toHaveBeenCalledWith("queue-valid-item", "overlay-1", undefined);
+			expect(removeFromClipQueue).toHaveBeenCalledWith("queue-valid-item", "overlay-1", undefined);
 		});
 	});
 

--- a/test/app/components/overlayPlayer.test.tsx
+++ b/test/app/components/overlayPlayer.test.tsx
@@ -776,6 +776,26 @@ describe("components/overlayPlayer", () => {
 		}
 	});
 
+	it("does not replay a skipped clip before the remaining session clips are exhausted", async () => {
+		const firstClip = buildClip("skip-repeat-a", { title: "skip-repeat-a", view_count: 300 });
+		const secondClip = buildClip("skip-repeat-b", { title: "skip-repeat-b", view_count: 200 });
+		const thirdClip = buildClip("skip-repeat-c", { title: "skip-repeat-c", view_count: 100 });
+		getTwitchClipBatch.mockResolvedValue([firstClip, secondClip, thirdClip]);
+
+		render(<OverlayPlayer overlay={buildOverlay({ playbackMode: "order", clipPackSize: 2 })} />);
+		await screen.findByText("skip-repeat-a");
+
+		const ws = MockWebSocket.instances[0];
+		await sendSocketPayload(ws, { type: "command", data: { name: "skip", data: "" } });
+		await waitFor(() => {
+			const laterFetchExcludesSkippedClip = getTwitchClipBatch.mock.calls.some((call) => {
+				const excludeIds = call[3];
+				return Array.isArray(excludeIds) && excludeIds.includes("skip-repeat-a");
+			});
+			expect(laterFetchExcludesSkippedClip).toBe(true);
+		});
+	});
+
 	it("crossfades to prefetched clip when incoming slot is ready near clip end", async () => {
 		jest.useFakeTimers();
 		const firstClip = buildClip("crossfade-a", { title: "crossfade-a", view_count: 900 });
@@ -1175,6 +1195,30 @@ describe("components/overlayPlayer", () => {
 		await waitFor(() => {
 			expect(removeFromModQueue).toHaveBeenCalledWith("queue-catch-next-item", "overlay-1", undefined);
 			expect(removeFromClipQueue).toHaveBeenCalledWith("queue-catch-next-item", "overlay-1", undefined);
+		});
+	});
+
+	it("drops an invalid queue-head clip and continues to the next queued clip", async () => {
+		const validClip = buildClip("queue-valid-next", { title: "queue-valid-next", view_count: 700 });
+		let queueCall = 0;
+		getFirstFromModQueue.mockImplementation(async () => {
+			queueCall += 1;
+			if (queueCall === 1) return { id: "queue-invalid-item", clipId: "queue-invalid-clip" };
+			if (queueCall === 2) return { id: "queue-valid-item", clipId: validClip.id };
+			return null;
+		});
+		getTwitchClip.mockImplementation(async (clipId: string) => {
+			if (clipId === validClip.id) return validClip;
+			return null;
+		});
+		getTwitchClipBatch.mockResolvedValue([]);
+
+		render(<OverlayPlayer overlay={buildOverlay({ playbackMode: "top" })} />);
+		await screen.findByText("queue-valid-next");
+
+		await waitFor(() => {
+			expect(removeFromModQueue).toHaveBeenCalledWith("queue-invalid-item", "overlay-1", undefined);
+			expect(removeFromClipQueue).toHaveBeenCalledWith("queue-invalid-item", "overlay-1", undefined);
 		});
 	});
 


### PR DESCRIPTION
This pull request improves the playback logic for queued clips and enhances test coverage for edge cases in the overlay player. The main changes ensure that queued clips are played in the correct order, invalid or missing clips at the queue head are properly discarded, and skipped clips are not replayed until all other session clips have been exhausted. Additionally, the changes refactor how played clips are tracked and update related tests and mocks for better reliability.

**Playback logic improvements:**

* Ensured that `getFirstFromClipQueueByOverlayId` and `getFirstFromModQueueByBroadcasterId` always select the oldest (head) queued item by explicitly ordering by `queuedAt` ascending (`asc`). [[1]](diffhunk://#diff-dc00fd9c8f984dd8b6381181fcd64415f4ceb7eb24e9826699ad5cea2ed575d1L1882-R1882) [[2]](diffhunk://#diff-dc00fd9c8f984dd8b6381181fcd64415f4ceb7eb24e9826699ad5cea2ed575d1L1993-R1993)
* Added logic to discard (remove) invalid queue items if a queued clip is missing or invalid, allowing playback to continue with the next valid queued clip. [[1]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234R868-R878) [[2]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234R887-R892) [[3]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234L985-R1013)
* Improved played clip tracking by centralizing logic in a new `markClipAsPlayed` function, and ensured it is consistently used throughout the overlay player. [[1]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234R490-R496) [[2]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234R1086) [[3]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234R1107) [[4]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234L1088-R1118) [[5]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234L1710-R1742) [[6]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234L1857-R1886) [[7]](diffhunk://#diff-c57eb85239b80f346a440ea52484d317b7c429f42b9576946e4f47dfdffab234L1868-R1896)

**Test and mock updates:**

* Added tests to verify that skipped clips are not replayed before all other session clips are played, and that invalid queue-head clips are dropped and playback continues. [[1]](diffhunk://#diff-d6fd157e910c86f12c8a59e62a5a87b99ff58764ba4bdfbb86342b1f10e7b309R779-R798) [[2]](diffhunk://#diff-d6fd157e910c86f12c8a59e62a5a87b99ff58764ba4bdfbb86342b1f10e7b309R1201-R1224)
* Updated test mocks and schemas to support new fields (`queuedAt`) and methods (`orderBy`, `asc`) required by the improved queue logic. [[1]](diffhunk://#diff-c8552b40b9ba072f105ec4d9f0359e8be9d5d680c42872238cb9d7e1a1b95020L101-R103) [[2]](diffhunk://#diff-c8552b40b9ba072f105ec4d9f0359e8be9d5d680c42872238cb9d7e1a1b95020R125) [[3]](diffhunk://#diff-8d35eee7640e2bf13938d4a315232f3dd8e098bdecaf24f19a3cd62c914b81b7R16-R22) [[4]](diffhunk://#diff-8d35eee7640e2bf13938d4a315232f3dd8e098bdecaf24f19a3cd62c914b81b7R42) [[5]](diffhunk://#diff-8d35eee7640e2bf13938d4a315232f3dd8e098bdecaf24f19a3cd62c914b81b7R104)

**Dependency updates:**

* Imported the `asc` function from `drizzle-orm` for ordering queries.