### PR TITLE
🐛 Fix runner build issue

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,7 @@ jobs:
           NODE
 
   build-and-push:
+    name: 📦 Build and push Docker image
     runs-on: ${{ matrix.runner }}
     needs: verify-runner
     strategy:
@@ -136,6 +137,7 @@ jobs:
           retention-days: 1
 
   merge:
+    name: 🔀 Merge platform digests and create manifest list
     runs-on: ubuntu-latest
     needs:
       - verify-runner

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           docker pull "$RUNNER_REPOSITORY:fp-$RUNNER_FINGERPRINT-manifest"
-          container="$(docker create "$RUNNER_REPOSITORY:fp-$RUNNER_FINGERPRINT-manifest")"
+          container="$(docker create "$RUNNER_REPOSITORY:fp-$RUNNER_FINGERPRINT-manifest" /bin/true)"
           trap 'docker rm "$container" >/dev/null 2>&1 || true' EXIT
           docker cp "$container:/manifest.json" /tmp/runner-manifest.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,3 +202,19 @@ jobs:
       - name: 🧪 Test Runner
         working-directory: packages/runner
         run: bun run test
+
+  runner-manifest:
+    name: 📋 Verify Runner manifest extraction
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📋 Test scratch-image manifest extraction
+        run: |
+          set -euo pipefail
+          manifest_dir="$(mktemp -d)"
+          printf '{"schemaVersion":1}\n' > "$manifest_dir/manifest.json"
+          printf 'FROM scratch\nCOPY manifest.json /manifest.json\n' > "$manifest_dir/Dockerfile"
+          docker build --tag clipify-runner-manifest-test "$manifest_dir"
+          container="$(docker create clipify-runner-manifest-test /bin/true)"
+          trap 'docker rm "$container" >/dev/null 2>&1 || true; rm -rf "$manifest_dir"' EXIT
+          docker cp "$container:/manifest.json" "$manifest_dir/copied-manifest.json"
+          cmp "$manifest_dir/manifest.json" "$manifest_dir/copied-manifest.json"

--- a/.github/workflows/runner-native.yml
+++ b/.github/workflows/runner-native.yml
@@ -217,7 +217,7 @@ jobs:
             if docker buildx imagetools inspect "$reference" >/dev/null 2>&1; then
               echo "Checking existing immutable artifact $reference"
               docker pull "$reference" >/dev/null
-              container="$(docker create "$reference" /bin/sh)"
+              container="$(docker create "$reference" /bin/true)"
               docker cp "$container:/metadata.json" "$RUNNER_ARTIFACT_WORK/$platform.metadata.json"
               docker rm "$container" >/dev/null
               node -e 'const fs=require("fs"); const expected=JSON.parse(fs.readFileSync(process.argv[1])); const actual=JSON.parse(fs.readFileSync(process.argv[2])); for(const k of ["platform","target","filename","sourceFingerprint","sha256","size"]) if(expected[k]!==actual[k]) throw new Error(`Existing artifact mismatch in ${k}`)' "$metadata" "$RUNNER_ARTIFACT_WORK/$platform.metadata.json"
@@ -249,7 +249,7 @@ jobs:
           if docker buildx imagetools inspect "$reference" >/dev/null 2>&1; then
             echo "Checking existing immutable manifest $reference"
             docker pull "$reference" >/dev/null
-            container="$(docker create "$reference" /bin/sh)"
+            container="$(docker create "$reference" /bin/true)"
             docker cp "$container:/manifest.json" "$RUNNER_ARTIFACT_WORK/existing-manifest.json"
             docker rm "$container" >/dev/null
             cmp -s "$RUNNER_ARTIFACT_WORK/manifest.json" "$RUNNER_ARTIFACT_WORK/existing-manifest.json" || { echo "Existing manifest differs; refusing to overwrite" >&2; exit 1; }
@@ -282,7 +282,7 @@ jobs:
             if [ -n "$versions" ]; then
               previous_alias_version_id="$(printf '%s' "$versions" | node scripts/runner-package-cleanup.mjs --pr "$RUNNER_PR_NUMBER" --mode preview-alias 2>/dev/null | head -n 1 || true)"
             fi
-            container="$(docker create "$alias" /bin/sh)"
+            container="$(docker create "$alias" /bin/true)"
             trap 'docker rm "$container" >/dev/null 2>&1 || true' EXIT
             docker cp "$container:/manifest.json" "$existing_manifest"
             existing_commit="$(node -e 'const fs=require("fs"); const m=JSON.parse(fs.readFileSync(process.argv[1])); process.stdout.write(m.sourceCommit || "")' "$existing_manifest")"
@@ -300,7 +300,7 @@ jobs:
             "$immutable"
 
           docker pull "$alias" >/dev/null
-          container="$(docker create "$alias" /bin/sh)"
+          container="$(docker create "$alias" /bin/true)"
           trap 'docker rm "$container" >/dev/null 2>&1 || true' EXIT
           docker cp "$container:/manifest.json" "$RUNNER_ARTIFACT_WORK/verified-preview-alias-manifest.json"
           cmp -s "$RUNNER_ARTIFACT_WORK/manifest.json" "$RUNNER_ARTIFACT_WORK/verified-preview-alias-manifest.json"


### PR DESCRIPTION
## What changed

- supply an explicit command when creating stopped containers from scratch-based Runner artifact images
- standardize manifest and metadata extraction on `/bin/true`
- add a CI regression check for the scratch-image `docker create` and `docker cp` flow

## Why

The v3.0.0 release verifier pulled the correct immutable Runner manifest image, but `docker create` failed because the scratch image intentionally has no default command. Supplying a command allows Docker to create the stopped container so the workflow can copy and validate `manifest.json`; nothing is executed inside the container.

## Impact

Release verification can validate the exact Runner fingerprint and platform digests before publishing the application image.

## Validation

- workflow YAML parses and passes Prettier
- `git diff --check` passes
- full pre-push suite: 84 suites and 832 tests passed
- the new GitHub Actions regression job performs the Docker-based integration check