### PR TITLE
Fix Next 16.2.12 patch installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       cache-key: ${{ steps.compute-key.outputs.key }}
-      cache-hit: ${{ steps.restore.outputs.cache-hit }}
     steps:
       - name: 📥 Check out repository
         uses: actions/checkout@v7
@@ -52,7 +51,7 @@ jobs:
       # compute the cache key once so downstream jobs can reuse it
       - name: 🔑 Compute cache key
         id: compute-key
-        run: echo "key=${{ runner.os }}-deps-${{ hashFiles('**/bun.lock') }}" >> "$GITHUB_OUTPUT"
+        run: echo "key=${{ runner.os }}-deps-${{ hashFiles('**/bun.lock', '**/package.json', '**/patches/*.patch') }}" >> "$GITHUB_OUTPUT"
 
       # try to restore an existing cache
       - name: ♻️ Restore Bun & node_modules cache
@@ -65,10 +64,12 @@ jobs:
             **/node_modules
           key: ${{ steps.compute-key.outputs.key }}
 
-      # only install if the cache did not exist
-      - name: 📦 Install dependencies
-        if: steps.restore.outputs.cache-hit != 'true'
+      # Always validate the lockfile and patches, even when node_modules came from cache.
+      - name: 📦 Validate and install dependencies
         run: bun install --frozen-lockfile
+
+      - name: 🩹 Verify patched dependencies
+        run: node scripts/validate-patched-dependencies.mjs
 
       # save a new cache entry when we had a miss
       - name: 💾 Save Bun & node_modules cache
@@ -193,6 +194,9 @@ jobs:
       - name: 📦 Install Runner dependencies
         working-directory: packages/runner
         run: bun install --frozen-lockfile
+      - name: 🩹 Verify Runner patched dependencies
+        working-directory: packages/runner
+        run: node ../../scripts/validate-patched-dependencies.mjs
       - name: 🔐 Verify native keyring binding
         working-directory: packages/runner
         run: node check-native.mjs

--- a/patches/next@16.2.12.patch
+++ b/patches/next@16.2.12.patch
@@ -1,5 +1,4 @@
 diff --git a/dist/server/lib/router-utils/proxy-request.js b/dist/server/lib/router-utils/proxy-request.js
-index de8549da03855f8ac804a26a240184d443dec6fc..b4f4936d20dc69e61e597185734088769917cc48 100644
 --- a/dist/server/lib/router-utils/proxy-request.js
 +++ b/dist/server/lib/router-utils/proxy-request.js
 @@ -1,4 +1,5 @@
@@ -8,10 +7,10 @@ index de8549da03855f8ac804a26a240184d443dec6fc..b4f4936d20dc69e61e59718573408876
  Object.defineProperty(exports, "__esModule", {
      value: true
  });
-@@ -22,12 +23,12 @@ async function proxyRequest(req, res, parsedUrl, upgradeHead, reqBody, proxyTime
-     delete parsedUrl.query;
-     parsedUrl.search = (0, _serverrouteutils.stringifyQuery)(req, query);
-     const target = _url.default.format(parsedUrl);
+@@ -26,12 +27,12 @@ async function proxyRequest(req, res, parsedUrl, upgradeHead, reqBody, proxyTime
+     // are not strictly equal due to lowercasing, IDN translation, IPv4 and IPv6 normalization, etc.
+     // We just make sure this is a valid URL since http-proxy doesn't validate.
+     new URL(target);
 -    const HttpProxy = require('next/dist/compiled/http-proxy');
      const proxy = new HttpProxy({
          target,
@@ -22,7 +21,7 @@ index de8549da03855f8ac804a26a240184d443dec6fc..b4f4936d20dc69e61e59718573408876
          // we limit proxy requests to 30s by default, in development
          // we don't time out WebSocket requests to allow proxying
          proxyTimeout: proxyTimeout === null ? undefined : proxyTimeout || 30000,
-@@ -44,6 +45,8 @@ async function proxyRequest(req, res, parsedUrl, upgradeHead, reqBody, proxyTime
+@@ -48,6 +49,8 @@ async function proxyRequest(req, res, parsedUrl, upgradeHead, reqBody, proxyTime
      // object will detect the disconnect, and we can abort the proxy's
      // connection.
      proxy.on('proxyReq', (proxyReq)=>{

--- a/scripts/validate-patched-dependencies.mjs
+++ b/scripts/validate-patched-dependencies.mjs
@@ -1,0 +1,26 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const packageRoot = resolve(process.argv[2] ?? ".");
+const packageJson = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
+const patchedDependencies = packageJson.patchedDependencies ?? {};
+
+for (const [specifier, patchFile] of Object.entries(patchedDependencies)) {
+	const versionSeparator = specifier.lastIndexOf("@");
+	if (versionSeparator <= 0) throw new Error(`Invalid patched dependency specifier: ${specifier}`);
+
+	const packageName = specifier.slice(0, versionSeparator);
+	const expectedVersion = specifier.slice(versionSeparator + 1);
+	const patchPath = resolve(packageRoot, patchFile);
+	if (!existsSync(patchPath)) throw new Error(`Missing patch for ${specifier}: ${patchFile}`);
+
+	const installedPackageJson = join(packageRoot, "node_modules", ...packageName.split("/"), "package.json");
+	if (!existsSync(installedPackageJson)) throw new Error(`Patched dependency is not installed: ${packageName}`);
+
+	const actualVersion = JSON.parse(readFileSync(installedPackageJson, "utf8")).version;
+	if (actualVersion !== expectedVersion) {
+		throw new Error(`Patch version mismatch for ${packageName}: patch targets ${expectedVersion}, installed ${actualVersion}`);
+	}
+}
+
+console.log(`Verified ${Object.keys(patchedDependencies).length} patched dependencies in ${packageRoot}`);

--- a/test/app/actions/twitch.sync.test.ts
+++ b/test/app/actions/twitch.sync.test.ts
@@ -283,7 +283,8 @@ describe("actions/twitch syncOwnerClipCache", () => {
 
 		// Incremental fetch uses deficit (5) then backfill loop exhausts budget or completes
 		expect(getSpy).toHaveBeenCalled();
-		expect(getSpy.mock.calls[0]?.[1]?.params?.first).toBe(5);
+		const requestConfig = getSpy.mock.calls[0]?.[1] as { params?: { first?: number } } | undefined;
+		expect(requestConfig?.params?.first).toBe(5);
 	});
 
 	it("skips sync work when incremental and backfill are not due", async () => {


### PR DESCRIPTION
## What changed

- port the existing Next proxy patch from 16.1.6 to 16.2.12
- make dependency caches sensitive to package manifests and patch files
- validate frozen installs and patched dependency versions on every CI run
- update one Axios mock assertion for the installed type definitions

## Root cause

Renovate updated the patchedDependencies reference but could not port the patch contents. CI keyed its dependency cache only by bun.lock and skipped bun install on cache hits, so the missing patch file was not detected before merge.

## Validation

- clean-worktree bun install --frozen-lockfile
- root and Runner patch validation
- root and Runner TypeScript checks
- 832 application tests and 20 Runner tests
- ESLint
- production Next.js build