### PR TITLE
Increase user understanding with privacy-aware telemetry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "clipify",
       "dependencies": {
+        "@grafana/faro-web-sdk": "^2.9.0",
         "@heroui/react": "^3.2.4",
         "@heroui/styles": "^3.2.4",
         "@sentry/nextjs": "^10.70.0",
@@ -294,6 +295,10 @@
 
     "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.6.2", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA=="],
 
+    "@grafana/faro-core": ["@grafana/faro-core@2.9.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/otlp-transformer": "^0.219.0" } }, "sha512-v7vrNYuoW273hOQ3rQgo3wYYBD8kH5TTfFes0dbsx2/8L+BclIsrsRCUHdlCqme2ZP42iyLkyPgCSDav8S0Niw=="],
+
+    "@grafana/faro-web-sdk": ["@grafana/faro-web-sdk@2.9.0", "", { "dependencies": { "@grafana/faro-core": "^2.9.0", "ua-parser-js": "1.0.41", "web-vitals": "^5.1.0" } }, "sha512-CfeIoW8m/9Y4LEASQpflhRSg1hJRqJ0gUADdmSFVI6f134+DWoT9e9qsO3v64mSuUPsdD3qYi2EkO+16u7hhTQ=="],
+
     "@heroui/react": ["@heroui/react@3.2.4", "", { "dependencies": { "@heroui/styles": "3.2.4", "@radix-ui/react-avatar": "1.1.11", "@react-stately/utils": "3.12.1", "@react-types/color": "3.2.0", "@react-types/shared": "3.36.1", "input-otp": "1.4.2", "tailwind-merge": "3.4.0", "tailwind-variants": "3.3.1" }, "peerDependencies": { "@react-aria/i18n": "^3.13.1", "@react-aria/ssr": "^3.10.1", "@react-aria/utils": "^3.34.1", "react": ">=19.0.0", "react-aria": "^3.51.0", "react-aria-components": "^1.20.0", "react-dom": ">=19.0.0", "tailwindcss": ">=4.0.0" } }, "sha512-ZXCTyz1G7bgCdHVxRPy4vIRI/wdb0ZvzEUJGG7CAEp0zqQsKrTH1o9i3Ns8yM6EidtAyfMosULN29gFA3wegBA=="],
 
     "@heroui/styles": ["@heroui/styles@3.2.4", "", { "dependencies": { "tailwind-variants": "3.3.1", "tw-animate-css": "1.4.0" }, "peerDependencies": { "tailwindcss": ">=4.0.0" } }, "sha512-tjiT7VFUSjw7TA6ZjeT+D3oX62+D27l7dhPwW+emwPnkdkRoKALFJEPBsxpmEI/x18uNkKFIoTk85bICyOO8Vg=="],
@@ -462,13 +467,23 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
-    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.220.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w=="],
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg=="],
 
     "@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
 
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.219.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/otlp-exporter-base": "0.219.0", "@opentelemetry/otlp-transformer": "0.219.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/sdk-trace-base": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw=="],
+
     "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw=="],
 
-    "@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.219.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/otlp-transformer": "0.219.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.219.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.219.0", "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/sdk-logs": "0.219.0", "@opentelemetry/sdk-metrics": "2.8.0", "@opentelemetry/sdk-trace-base": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.219.0", "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg=="],
 
     "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw=="],
 
@@ -2004,6 +2019,8 @@
 
     "typescript-eslint": ["typescript-eslint@8.62.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.62.1", "@typescript-eslint/parser": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1", "@typescript-eslint/utils": "8.62.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw=="],
 
+    "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
+
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
@@ -2027,6 +2044,8 @@
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 
     "watchpack": ["watchpack@2.5.2", "", { "dependencies": { "graceful-fs": "^4.1.2" } }, "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg=="],
+
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
@@ -2155,6 +2174,28 @@
     "@jest/types/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@mapbox/node-pre-gyp/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ=="],
+
+    "@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.220.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w=="],
+
+    "@opentelemetry/otlp-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ=="],
+
+    "@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/sdk-trace/@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
+
+    "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
 
     "@react-aria/color/@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
 

--- a/docs/observability-privacy-rollout.md
+++ b/docs/observability-privacy-rollout.md
@@ -1,0 +1,47 @@
+# Observability and privacy rollout
+
+## Data ownership
+
+- Plausible: aggregate acquisition and conversion events.
+- Grafana Faro: operational browser errors, Web Vitals, and navigation/resource performance. The configured SDK disables session tracking, console capture, tracing, geolocation, replay, and user metadata.
+- Microsoft Clarity: consented session recordings, heatmaps, and qualitative funnel events. Advertising storage is always denied.
+- Sentry/Bugsink: retained during the Grafana parity period. Remove only after production Faro and structured-log alerts have been verified.
+
+## Required environment
+
+- `NEXT_PUBLIC_FARO_COLLECTOR_URL=<Grafana Frontend Observability collector URL>`
+- `NEXT_PUBLIC_CLARITY_PROJECT_ID=<Clarity project ID>`
+- `NEXT_PUBLIC_ADOPT_ANALYTICS_TAG_ID=<GoAdopt Analytics tag UUID>`
+- Release and environment metadata are embedded automatically by the build; no runtime variables are required.
+
+Missing collector/project values leave the corresponding integration disabled.
+
+## GoAdopt configuration
+
+1. Add Microsoft Clarity as an Analytics vendor and use its tag UUID as `NEXT_PUBLIC_ADOPT_ANALYTICS_TAG_ID`.
+2. Do not classify Clarity as Required. Map only Analytics consent to Clarity `analytics_Storage`; `ad_Storage` remains denied.
+3. List Grafana Cloud Frontend Observability as operational monitoring. This implementation creates no Faro cookie or web-storage session identifier.
+4. Rescan after deployment and verify `_clck` and `_clsk` appear only after Analytics consent.
+
+## Privacy-policy update checklist
+
+The hosted policy must be updated before Clarity is enabled. The final language requires legal review and should:
+
+- Remove the current statement that accessing the service itself constitutes consent.
+- Describe browser/device metadata, performance timings, navigation/resource measurements, frontend errors, and—only with consent—DOM reconstructions, clicks, scrolling, and interaction events.
+- Separate purposes and legal bases: minimized reliability monitoring and aggregate measurement under Article 6(1)(f) GDPR; Clarity behavior analytics under Article 6(1)(a) GDPR and section 25(1) TDDDG.
+- Explain Clipify's legitimate interests, safeguards, Article 21 objection right, and a contact path for objections.
+- Name Grafana Labs and Microsoft Ireland, their roles, processing regions, subprocessors, DPAs, and applicable international-transfer safeguards.
+- Disclose configured retention: Grafana logs/traces 30 days, Grafana metrics up to 13 months, Clarity playback 30 days, Clarity click/heatmap and labeled/favorited records 9 months, and Plausible aggregates 24 months.
+- Explain consent withdrawal and data-subject requests, and reconcile the inconsistent `contact@clipify.us` / `mail@thedannicraft.de` contact addresses.
+
+The hosted Cookie Policy must add `_clck` and `_clsk`, their purposes and durations, while documenting that the configured Faro profile uses neither cookies nor session storage.
+
+## Production acceptance
+
+- Reject/no choice: no request to Clarity and no Clarity cookies.
+- Accept Analytics: recordings and heatmaps operate only on eligible public/dashboard routes; advertising storage remains denied.
+- Withdraw Analytics: cookies are cleared and the document reloads to unload the recorder.
+- Faro: no cookie/localStorage/sessionStorage identifier and no sensitive URL/query/form data in sampled payloads.
+- Shared product events contain only the central low-cardinality allowlist.
+- Grafana receives searchable browser errors and structured server errors before Sentry is removed.

--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,7 @@ const nextConfigPromise = Promise.resolve(drizzle).then(
 				"**": [...drizzle],
 			},
 			poweredByHeader: false,
+			env: { APP_RELEASE: process.env.APP_RELEASE },
 			async headers() {
 				const baseSecurityHeaders = [
 					{ key: "X-Content-Type-Options", value: "nosniff" },

--- a/package.json
+++ b/package.json
@@ -26,13 +26,16 @@
 		"stream:test": "tsx scripts/stream-test.ts"
 	},
 	"dependencies": {
+		"@grafana/faro-web-sdk": "^2.9.0",
 		"@heroui/react": "^3.2.4",
 		"@heroui/styles": "^3.2.4",
 		"@sentry/nextjs": "^10.70.0",
 		"@tabler/icons-react": "^3.46.0",
+		"@types/ffbinaries": "^1.1.5",
 		"axios": "^1.19.0",
 		"dotenv": "^17.4.2",
 		"drizzle-orm": "^0.45.2",
+		"fluent-ffmpeg": "^2.1.3",
 		"jsonwebtoken": "^9.0.3",
 		"minimatch": "^10.2.6",
 		"motion": "^13.1.0",
@@ -52,9 +55,7 @@
 		"tailwind-variants": "^3.3.1",
 		"usesend-js": "^1.6.3",
 		"ws": "^8.21.3",
-		"xss": "^1.0.15",
-		"@types/ffbinaries": "^1.1.5",
-		"fluent-ffmpeg": "^2.1.3"
+		"xss": "^1.0.15"
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "^4.3.3",

--- a/scripts/build-app.mjs
+++ b/scripts/build-app.mjs
@@ -3,10 +3,11 @@ import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
+const release = process.env.APP_RELEASE ?? process.env.SOURCE_REVISION ?? process.env.GITHUB_SHA ?? `build-${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${crypto.randomBytes(4).toString("hex")}`;
 const plausibleScriptName = process.env.NEXT_PUBLIC_PLAUSIBLE_SCRIPT_NAME ?? process.env.PLAUSIBLE_SCRIPT_NAME ?? `${crypto.randomInt(1000, 10000)}-${crypto.randomBytes(8).toString("hex")}`;
 const result = spawnSync(process.execPath, [require.resolve("next/dist/bin/next"), "build", ...process.argv.slice(2)], {
 	stdio: "inherit",
-	env: { ...process.env, PLAUSIBLE_SCRIPT_NAME: plausibleScriptName },
+	env: { ...process.env, APP_RELEASE: release, NEXT_PUBLIC_APP_RELEASE: release, PLAUSIBLE_SCRIPT_NAME: plausibleScriptName },
 });
 
 if (result.error) throw result.error;

--- a/src/app/callback/route.ts
+++ b/src/app/callback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import jwt, { type JwtPayload } from "jsonwebtoken";
 import * as Sentry from "@sentry/nextjs";
+import { logServerError } from "@lib/serverLogger";
 
 import { exchangeAccesToken } from "@actions/twitch";
 import { setAccessToken, touchUser } from "@actions/database";
@@ -115,6 +116,7 @@ export async function GET(request: NextRequest) {
 		return NextResponse.redirect(returnUrl);
 	} catch (error) {
 		const errorCode = await Sentry.captureException(error);
+		logServerError("OAuth callback failed", error, { route: "/callback" });
 		return authUser(undefined, "serverError", errorCode);
 	}
 }

--- a/src/app/components/TelemetryProvider.tsx
+++ b/src/app/components/TelemetryProvider.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { getWebInstrumentations, initializeFaro, UserActionInstrumentation } from "@grafana/faro-web-sdk";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+const CLARITY_EXCLUDED_PREFIXES = ["/admin", "/auth", "/callback", "/payment", "/embed", "/overlay", "/controller", "/demoPlayer", "/runner/enroll"];
+declare global {
+	interface Window {
+		adoptCB?: (consent: { optInTags?: string[]; optOutTags?: string[] }) => void;
+	}
+}
+let faroInitialized = false;
+let clarityLoaded = false;
+const SENSITIVE_FIELD = /token|secret|password|authorization|cookie|email|code|state|dsn/i;
+function sanitizeTelemetryItem<T>(item: T): T {
+	return JSON.parse(JSON.stringify(item), (key, value) => {
+		if (SENSITIVE_FIELD.test(key)) return "[REDACTED]";
+		if (typeof value === "string" && value.startsWith("http")) {
+			try {
+				const url = new URL(value);
+				url.search = "";
+				url.hash = "";
+				return url.toString();
+			} catch {
+				return value;
+			}
+		}
+		return value;
+	}) as T;
+}
+function startFaro() {
+	const url = process.env.NEXT_PUBLIC_FARO_COLLECTOR_URL;
+	if (faroInitialized || !url) return;
+	initializeFaro({ url, app: { name: "clipify-web", version: process.env.NEXT_PUBLIC_APP_RELEASE || "unknown", environment: process.env.NODE_ENV }, instrumentations: getWebInstrumentations({ captureConsole: false }).filter((item) => !(item instanceof UserActionInstrumentation)), sessionTracking: { enabled: false }, trackGeolocation: false, beforeSend: sanitizeTelemetryItem, ignoreUrls: [/analytics\.thedannicraft\.de/i, /clarity\.ms/i, /goadopt\.io/i, /affiliate\.clipify\.us/i] });
+	faroInitialized = true;
+}
+function stopClarityCookies() {
+	for (const name of ["_clck", "_clsk"]) document.cookie = `${name}=; Max-Age=0; path=/; SameSite=Lax`;
+}
+function applyClarityConsent(granted: boolean, eligibleRoute: boolean) {
+	const projectId = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID;
+	if (!projectId || !eligibleRoute) return;
+	window.clarity =
+		window.clarity ||
+		function (...args: unknown[]) {
+			(window.clarity!.q = window.clarity!.q || []).push(args);
+		};
+	window.clarity("consentv2", { analytics_Storage: granted ? "granted" : "denied", ad_Storage: "denied" });
+	if (!granted) {
+		stopClarityCookies();
+		if (clarityLoaded) window.location.reload();
+		return;
+	}
+	if (clarityLoaded) return;
+	const script = document.createElement("script");
+	script.async = true;
+	script.src = `https://www.clarity.ms/tag/${encodeURIComponent(projectId)}`;
+	document.head.appendChild(script);
+	clarityLoaded = true;
+}
+export default function TelemetryProvider() {
+	const pathname = usePathname();
+	useEffect(() => startFaro(), []);
+	useEffect(() => {
+		const analyticsTagId = process.env.NEXT_PUBLIC_ADOPT_ANALYTICS_TAG_ID;
+		const eligibleRoute = !CLARITY_EXCLUDED_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+		if (!eligibleRoute && clarityLoaded) {
+			window.location.reload();
+			return;
+		}
+		window.adoptCB = (consent) => applyClarityConsent(Boolean(analyticsTagId && consent.optInTags?.includes(analyticsTagId)), eligibleRoute);
+		return () => {
+			delete window.adoptCB;
+		};
+	}, [pathname]);
+	return null;
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
+import { reportFrontendError } from "@lib/telemetry";
 import { Button } from "@heroui/react";
 
 import { useEffect } from "react";
@@ -9,6 +10,7 @@ import NextErrorPage from "@components/nextErrorPage";
 export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
 	useEffect(() => {
 		Sentry.captureException(error);
+		reportFrontendError(error, "app_error_boundary");
 	}, [error]);
 
 	return (

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
+import { reportFrontendError } from "@lib/telemetry";
 import { useEffect } from "react";
 import { Button, Link } from "@heroui/react";
 import { buttonVariants } from "@heroui/styles";
@@ -10,6 +11,7 @@ import NextErrorPage from "@components/nextErrorPage";
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
 	useEffect(() => {
 		Sentry.captureException(error);
+		reportFrontendError(error, "global_error_boundary");
 	}, [error]);
 
 	return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { getBaseUrl } from "@actions/utils";
 import PlausibleClient from "./PlausibleClient";
 import Script from "next/script";
 import AdOptScript from "./components/AdOptScript";
+import TelemetryProvider from "./components/TelemetryProvider";
 
 const baseUrl = await getBaseUrl();
 const manifestUrl = new URL("manifest.webmanifest", baseUrl);
@@ -50,6 +51,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
 				<link rel='preconnect' href='https://affiliate.clipify.us' crossOrigin='anonymous' />
 			</head>
 			<body className='min-h-screen bg-background text-foreground' suppressHydrationWarning>
+				<TelemetryProvider />
 				<AdOptScript />
 				<Script id='affiliate-program-tracker' src='https://affiliate.clipify.us/tracking/program-1.js' strategy='afterInteractive' />
 				<PlausibleClient>

--- a/src/app/lib/paywallTracking.ts
+++ b/src/app/lib/paywallTracking.ts
@@ -1,9 +1,11 @@
 "use client";
-
+import { emitProductEvent, type ProductEventProperties } from "@lib/telemetry";
 export type PaywallEvent = "paywall_impression" | "paywall_cta_click" | "checkout_start" | "checkout_success" | "trial_started" | "trial_expired_view";
-
-type PlausibleFn = (eventName: string, options?: { props?: Record<string, string | number | boolean | null | undefined> }) => void;
-
-export function trackPaywallEvent(plausible: PlausibleFn, eventName: PaywallEvent, props?: Record<string, string | number | boolean | null | undefined>) {
-	plausible(eventName, { props });
+type PlausibleFn = (eventName: string, options?: { props?: ProductEventProperties }) => void;
+export function trackPaywallEvent(plausible: PlausibleFn, eventName: PaywallEvent, props?: ProductEventProperties) {
+	if (eventName === "trial_started" || eventName === "trial_expired_view") {
+		plausible(eventName, { props });
+		return;
+	}
+	emitProductEvent(eventName, props, plausible);
 }

--- a/src/app/lib/serverLogger.ts
+++ b/src/app/lib/serverLogger.ts
@@ -1,0 +1,19 @@
+import crypto from "node:crypto";
+
+type LogContext = Record<string, unknown>;
+const SENSITIVE_KEY = /token|secret|password|authorization|cookie|email|code|state|dsn/i;
+
+function sanitize(value: unknown, depth = 0): unknown {
+	if (depth > 3) return "[TRUNCATED]";
+	if (value instanceof Error) return { name: value.name, message: value.message.slice(0, 500), stack: value.stack?.split("\n").slice(0, 12).join("\n") };
+	if (Array.isArray(value)) return value.slice(0, 20).map((item) => sanitize(item, depth + 1));
+	if (value && typeof value === "object") return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, SENSITIVE_KEY.test(key) ? "[REDACTED]" : sanitize(item, depth + 1)]));
+	if (typeof value === "string") return value.replace(/([?&](?:token|code|state|secret)=[^&\s]+)/gi, "$1[REDACTED]").slice(0, 1000);
+	return value;
+}
+
+export function logServerError(message: string, error: unknown, context: LogContext = {}) {
+	const incidentId = crypto.randomUUID();
+	console.error(JSON.stringify({ timestamp: new Date().toISOString(), severity: "error", message, incidentId, environment: process.env.NODE_ENV, release: process.env.APP_RELEASE || "unknown", context: sanitize(context), error: sanitize(error) }));
+	return incidentId;
+}

--- a/src/app/lib/telemetry.ts
+++ b/src/app/lib/telemetry.ts
@@ -1,0 +1,71 @@
+"use client";
+import { faro } from "@grafana/faro-web-sdk";
+export type ProductEventName = "auth_start" | "auth_success" | "overlay_created" | "paywall_impression" | "paywall_cta_click" | "paywall_dismissed" | "checkout_start" | "checkout_success" | "form_validation_blocked" | "action_failed" | "newsletter_subscription" | "clip_played";
+type EventProperty = string | number | boolean | null | undefined;
+export type ProductEventProperties = Record<string, EventProperty>;
+type Route = { plausible?: boolean; clarity?: boolean; prioritizeClarity?: boolean };
+const ROUTES: Record<ProductEventName, Route> = {
+	auth_start: { plausible: true, clarity: true, prioritizeClarity: true },
+	auth_success: { plausible: true, clarity: true },
+	overlay_created: { plausible: true, clarity: true },
+	paywall_impression: { plausible: true, clarity: true },
+	paywall_cta_click: { plausible: true, clarity: true, prioritizeClarity: true },
+	paywall_dismissed: { clarity: true, prioritizeClarity: true },
+	checkout_start: { plausible: true, clarity: true, prioritizeClarity: true },
+	checkout_success: { plausible: true, clarity: true, prioritizeClarity: true },
+	form_validation_blocked: { clarity: true, prioritizeClarity: true },
+	action_failed: { clarity: true, prioritizeClarity: true },
+	newsletter_subscription: { plausible: true },
+	clip_played: { plausible: true },
+};
+const ALLOWED_PROPERTIES = new Set(["source", "product", "feature", "billing_cycle", "cycle", "plan", "placement", "page_area", "funnel_stage", "reason", "value"]);
+declare global {
+	interface Window {
+		plausible?: (name: string, options?: { props?: ProductEventProperties }) => void;
+		clarity?: ((command: string, ...args: unknown[]) => void) & { q?: unknown[] };
+	}
+}
+export function sanitizeEventProperties(properties: ProductEventProperties = {}) {
+	return Object.fromEntries(
+		Object.entries(properties)
+			.filter(([key, value]) => ALLOWED_PROPERTIES.has(key) && ["string", "number", "boolean"].includes(typeof value))
+			.map(([key, value]) => [key, typeof value === "string" ? value.slice(0, 100) : value]),
+	);
+}
+export function emitProductEvent(name: ProductEventName, properties: ProductEventProperties | undefined, plausibleOverride?: (name: string, options?: { props?: ProductEventProperties }) => void) {
+	if (typeof window === "undefined") {
+		plausibleOverride?.(name, { props: properties });
+		return;
+	}
+	const route = ROUTES[name];
+	const props = properties === undefined ? undefined : sanitizeEventProperties(properties);
+	if (route.plausible)
+		try {
+			(plausibleOverride || window.plausible)?.(name, { props });
+		} catch {
+			/* best-effort */
+		}
+	if (route.clarity && window.clarity)
+		try {
+			window.clarity("event", name);
+			for (const [key, value] of Object.entries(props || {})) window.clarity("set", key, String(value));
+			if (route.prioritizeClarity) window.clarity("upgrade", name);
+		} catch {
+			/* best-effort */
+		}
+}
+export function reportFrontendError(error: unknown, context = "frontend") {
+	const normalized = error instanceof Error ? error : new Error("Unknown frontend error");
+	try {
+		faro.api.pushError(normalized, { context: { source: context.slice(0, 80) } });
+	} catch {
+		/* reporting must not throw */
+	}
+	if (typeof window !== "undefined" && window.clarity)
+		try {
+			window.clarity("event", "frontend_error");
+			window.clarity("upgrade", "frontend_error");
+		} catch {
+			/* generic label only */
+		}
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { logServerError } from "@lib/serverLogger";
 
 export async function register() {
 	if (process.env.NEXT_RUNTIME === "nodejs") {
@@ -14,4 +15,7 @@ export async function register() {
 	}
 }
 
-export const onRequestError = Sentry.captureRequestError;
+export const onRequestError = (...args: Parameters<typeof Sentry.captureRequestError>) => {
+	logServerError("Unhandled Next.js request error", args[0], { request: args[1] });
+	return Sentry.captureRequestError(...args);
+};

--- a/test/app/lib/telemetry.test.ts
+++ b/test/app/lib/telemetry.test.ts
@@ -1,0 +1,27 @@
+import { emitProductEvent, sanitizeEventProperties } from "@lib/telemetry";
+
+jest.mock("@grafana/faro-web-sdk", () => ({ faro: { api: { pushError: jest.fn() } } }));
+
+describe("product telemetry", () => {
+	beforeEach(() => {
+		delete window.plausible;
+		delete window.clarity;
+	});
+	it("allows only approved, low-cardinality properties", () => {
+		expect(sanitizeEventProperties({ source: "pricing", userId: "secret", reason: "x".repeat(120) })).toEqual({ source: "pricing", reason: "x".repeat(100) });
+	});
+	it("routes funnel events to Plausible and Clarity and prioritizes CTAs", () => {
+		window.plausible = jest.fn();
+		window.clarity = jest.fn();
+		emitProductEvent("paywall_cta_click", { source: "pricing", userId: "secret" });
+		expect(window.plausible).toHaveBeenCalledWith("paywall_cta_click", { props: { source: "pricing" } });
+		expect(window.clarity).toHaveBeenCalledWith("event", "paywall_cta_click");
+		expect(window.clarity).toHaveBeenCalledWith("upgrade", "paywall_cta_click");
+	});
+	it("keeps destination failures from escaping", () => {
+		window.plausible = jest.fn(() => {
+			throw new Error("blocked");
+		});
+		expect(() => emitProductEvent("checkout_start", { source: "settings" })).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

Adds a privacy-aware telemetry strategy to improve understanding of Clipify's user experience and conversion funnel:

- adds Grafana Faro for privacy-minimized browser RUM and frontend error reporting
- adds consent-gated Microsoft Clarity session recordings, heatmaps, and prioritized CTA/error sessions
- introduces a typed shared product-event dispatcher for Plausible and Clarity
- adds structured, redacted server errors for Grafana Logs while retaining Sentry during parity validation
- generates and embeds an immutable release identifier during the application/image build

## Privacy and behavior

- Faro session tracking, persistent storage, user-action instrumentation, console capture, tracing, geolocation, replay, and user metadata are disabled
- Clarity loads only after GoAdopt Analytics consent and stays disabled on sensitive/excluded routes
- Clarity advertising storage is always denied
- event properties pass through a central low-cardinality allowlist
- URLs and sensitive telemetry fields are redacted before Faro transport

## Required before merge

> [!IMPORTANT]
> Delete `docs/observability-privacy-rollout.md` before merging this PR. It is a temporary implementation and legal-review handoff document and should not ship with the application.

Production rollout must also update the hosted GoAdopt privacy and cookie policies before enabling Clarity. Sentry should only be removed after Faro and Grafana Logs parity is verified in production.

## Validation

- `bun run test` — 85 suites, 836 tests passed
- `bun run app:typecheck` — passed
- `bun run app:lint` — passed with two unrelated pre-existing warnings
- `bun run app:build` — passed
- `git diff --check` — passed
